### PR TITLE
feat: expose default context metadata properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Here is an example of which data is stored on your document after selecting an a
     "bytes": 547710,
     "duration": null,
     "tags": [],
-    "metadata": {},
+    "context": {
+      "custom": {
+        "alt": "alternative text for image"
+      }
+    },
     "created_at": "2021-03-23T04:44:13Z",
     "access_mode": "public",
     "_version": 1,
@@ -91,7 +95,11 @@ You can create a transformation when selecting the asset, and this information i
     "bytes": 547710,
     "duration": null,
     "tags": null,
-    "metadata": [],
+    "context": {
+      "custom": {
+        "alt": "alternative text for image"
+      }
+    },
     "created_at": "2021-03-23T04:44:13Z",
     "derived": [
       {

--- a/sanity.json
+++ b/sanity.json
@@ -6,6 +6,14 @@
   "parts": [
     {
       "implements": "part:@sanity/base/schema-type",
+      "path": "schema/cloudinaryAssetContext"
+    },
+    {
+      "implements": "part:@sanity/base/schema-type",
+      "path": "schema/cloudinaryAssetContextCustom"
+    },
+    {
+      "implements": "part:@sanity/base/schema-type",
       "path": "schema/cloudinaryAssetDerived"
     },
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import cloudinary from './schema/cloudinaryAsset';
 import derived from './schema/cloudinaryAssetDerived';
+import context from './schema/cloudinaryAssetContext';
+import custom from './schema/cloudinaryAssetContextCustom';
 
-export { cloudinary, derived };
+export { cloudinary, derived, context, custom };

--- a/src/schema/cloudinaryAsset.ts
+++ b/src/schema/cloudinaryAsset.ts
@@ -87,7 +87,10 @@ export default {
       type: 'string',
       name: 'access_mode',
     },
-    // context array of unknown content
+    {
+      type: 'cloudinary.assetContext',
+      name: 'context',
+    },
     // metadata array of unknown content
   ],
   inputComponent: CloudinaryInput,

--- a/src/schema/cloudinaryAssetContext.ts
+++ b/src/schema/cloudinaryAssetContext.ts
@@ -1,0 +1,14 @@
+export type CloudinaryAssetContext = {
+  custom: object;
+};
+  
+export default {
+  type: 'object',
+  name: 'cloudinary.assetContext',
+  fields: [
+    {
+      type: 'cloudinary.assetContextCustom',
+      name: 'custom',
+    },
+  ],
+};

--- a/src/schema/cloudinaryAssetContextCustom.ts
+++ b/src/schema/cloudinaryAssetContextCustom.ts
@@ -1,0 +1,19 @@
+export type CloudinaryAssetContextCustom = {
+  alt: string;
+  caption: string;
+};
+
+export default {
+  type: 'object',
+  name: 'cloudinary.assetContextCustom',
+  fields: [
+    {
+      type: 'string',
+      name: 'alt',
+    },
+    {
+      type: 'string',
+      name: 'caption',
+    },
+  ],
+};


### PR DESCRIPTION
This PR exposes the context default metadata properties as it is defined on Cloudinary.

This would give the ability to get both `alt` and `caption` properties when they are available for an image.