### PR TITLE
fix: transform cloudinary metadata to no special characters

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,9 @@ export type CloudinaryAssetResponse = {
   width: number
   height: number
   bytes: number
+  context?: {
+    custom: Record<string, string>
+  }
   derived?: CloudinaryDerivative[]
 }
 


### PR DESCRIPTION
When adding metadata to the cloudinary asset in Cloudinary, the studio would crash if this data contained any special characters. 
This PR removes these special characters. 

PS: This has been tested in the Studio code for the plugin, but after this release, it should be tested again. 