### PR TITLE
adds cloudinaryReferencePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > This combines the sanity-plugin-cloudinary AND sanity-plugin-asset-source-cloudinary plugins previously for V2,
 > into a single plugin for V3.
 >
-> For the v2 versions of these, please refer to the 
+> For the v2 versions of these, please refer to the
 > [v2-branch for sanity-plugin-cloudinary](https://github.com/sanity-io/sanity-plugin-cloudinary/tree/studio-v2) and
 > [sanity-plugin-asset-source-cloudinary](https://github.com/sanity-io/sanity-plugin-asset-source-cloudinary).
 
@@ -22,10 +22,11 @@ yarn add sanity-plugin-cloudinary
 
 ## Usage
 
-There are two plugins in this package:
+There are three plugins in this package:
 
 - `cloudinaryAssetSourcePlugin` - use this if you intend to serve Cloudinary images from the Sanity CDN
 - `cloudinarySchemaPlugin` - use this if you intend to serve Cloudinary images from the Cloudinary CDN
+- `cloudinaryReferencePlugin` - use this if you want to reference Cloudinary assets as document references
 
 Also see notes below on how Cloudinary config should be provided.
 
@@ -91,6 +92,40 @@ Now you can declare a field to be `cloudinary.asset` in your schema
       description: "This asset is served from Cloudinary",
     }
 ```
+
+## Cloudinary Reference Assets
+
+This plugin mode allows you to store Cloudinary assets as document references, which can be useful for reusing the same asset across multiple documents.
+
+```js
+import {defineConfig} from 'sanity'
+import {cloudinaryReferencePlugin} from 'sanity-plugin-cloudinary'
+
+export default defineConfig({
+  /*...*/
+  plugins: [cloudinaryReferencePlugin()],
+})
+```
+
+Now you can declare a field to be a reference to a Cloudinary asset:
+
+```javascript
+{
+  type: "cloudinaryAssetReference",
+  name: "image",
+  description: "This is a reference to a Cloudinary asset document",
+}
+```
+
+The plugin creates and maintains document references automatically. When you select an asset through the Cloudinary Media Library, it will:
+1. Create a `cloudinaryAssetDocument` if the asset doesn't exist yet in your dataset
+2. Update the asset if it already exists
+3. Store a reference to the asset document in your current document
+
+This approach is particularly useful for:
+- Reusing the same assets across multiple documents
+- Updating assets in one place and having the changes reflected everywhere
+- Managing assets separately from the content that uses them
 
 ## Config
 

--- a/src/components/CloudinaryReferenceInput.tsx
+++ b/src/components/CloudinaryReferenceInput.tsx
@@ -31,7 +31,7 @@ export function CloudinaryReferenceInput(props: any) {
       }
 
       // Create a unique ID for this asset based on its Cloudinary public_id
-      const assetId = `cloudinary-${asset.public_id.replace(/\//g, '-')}`
+      const assetId = `cloudinary-${asset.public_id.replace(/\//g, '-').replace(/\./g, '_')}`
 
       try {
         // Check if this asset already exists in Sanity

--- a/src/components/CloudinaryReferenceInput.tsx
+++ b/src/components/CloudinaryReferenceInput.tsx
@@ -1,0 +1,172 @@
+import React, {useCallback, useState} from 'react'
+import {Button, Stack, Flex, Grid} from '@sanity/ui'
+import {useClient} from 'sanity'
+import {PatchEvent, set, unset} from 'sanity'
+import {nanoid} from 'nanoid'
+import {useSecrets} from '@sanity/studio-secrets'
+import {PlugIcon} from '@sanity/icons'
+import {ReferencePreview} from './ReferencePreview'
+import {openMediaSelector} from '../utils'
+import SecretsConfigView, {namespace, Secrets} from './SecretsConfigView'
+import {InsertHandlerParams} from '../types'
+
+export function CloudinaryReferenceInput(props: any) {
+  const {onChange, value} = props
+  const [showSettings, setShowSettings] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const {secrets} = useSecrets<Secrets>(namespace)
+  const client = useClient({apiVersion: '2023-01-01'})
+
+  const cloudName = secrets?.cloudName
+  const apiKey = secrets?.apiKey
+  const hasConfig = apiKey && cloudName
+
+  // Handle selecting an asset from Cloudinary
+  const handleSelect = useCallback(
+    async (payload: InsertHandlerParams) => {
+      const [asset] = payload.assets
+
+      if (!asset) {
+        return
+      }
+
+      // Create a unique ID for this asset based on its Cloudinary public_id
+      const assetId = `cloudinary-${asset.public_id.replace(/\//g, '-')}`
+
+      try {
+        // Check if this asset already exists in Sanity
+        const existingAsset = await client.fetch(
+          `*[_type == "cloudinaryAssetDocument" && asset.public_id == $publicId][0]`,
+          {publicId: asset.public_id}
+        )
+
+        if (existingAsset) {
+          // Update the existing asset
+          await client.patch(existingAsset._id).set({asset: asset}).commit()
+
+          // Set reference to the existing asset
+          onChange(
+            PatchEvent.from(
+              set({
+                _type: 'reference',
+                _ref: existingAsset._id,
+                _weak: true,
+              })
+            )
+          )
+        } else {
+          // Create a new asset document
+          const newAsset = await client.create({
+            _id: assetId,
+            _type: 'cloudinaryAssetDocument',
+            asset: {
+              ...asset,
+              _type: 'cloudinaryAssetReference',
+              _key: nanoid(),
+            },
+          })
+
+          // Set reference to the new asset
+          onChange(
+            PatchEvent.from(
+              set({
+                _type: 'reference',
+                _ref: newAsset._id,
+                _weak: true,
+              })
+            )
+          )
+        }
+      } catch (err) {
+        console.error('Error creating/updating Cloudinary asset:', err)
+      }
+    },
+    [client, onChange]
+  )
+
+  // Action to open the media selector
+  const handleOpenSelector = useCallback(() => {
+    if (!hasConfig) {
+      setShowSettings(true)
+      return
+    }
+
+    setIsLoading(true)
+
+    // Open the media selector
+    try {
+      openMediaSelector(
+        cloudName!,
+        apiKey!,
+        false, // single selection
+        (payload) => {
+          handleSelect(payload)
+          setIsLoading(false)
+        },
+        undefined,
+        () => {
+          setIsLoading(false)
+        }
+      )
+
+      // Set a timeout to reset loading state if modal takes too long
+      setTimeout(() => {
+        setIsLoading(false)
+      }, 30000) // 30 seconds timeout as fallback
+    } catch (error) {
+      console.error('Error opening Cloudinary media selector:', error)
+      setIsLoading(false)
+    }
+  }, [cloudName, apiKey, hasConfig, handleSelect])
+
+  return (
+    <Stack space={3}>
+      {showSettings && <SecretsConfigView onClose={() => setShowSettings(false)} />}
+
+      <Flex justify="flex-end">
+        <Button
+          color="primary"
+          icon={PlugIcon}
+          mode="bleed"
+          title="Configure"
+          onClick={() => setShowSettings(true)}
+          tabIndex={1}
+          text={hasConfig ? undefined : 'Configure Cloudinary plugin'}
+        />
+      </Flex>
+
+      <Flex style={{textAlign: 'center', width: '100%'}} marginBottom={2}>
+        <ReferencePreview value={value} />
+      </Flex>
+
+      <Stack space={2}>
+        <Grid gap={1} style={{gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))'}}>
+          <Button
+            text={
+              hasConfig
+                ? isLoading
+                  ? 'Opening Media Library...'
+                  : 'Select Asset'
+                : 'Configure Cloudinary to Select Assets'
+            }
+            onClick={handleOpenSelector}
+            tone="primary"
+            mode="ghost"
+            disabled={(!hasConfig && !showSettings) || isLoading}
+            loading={isLoading}
+          />
+
+          {value && (
+            <Button
+              text="Remove"
+              tone="critical"
+              mode="ghost"
+              onClick={() => onChange(PatchEvent.from(unset()))}
+              disabled={isLoading}
+            />
+          )}
+        </Grid>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/components/ReferencePreview.tsx
+++ b/src/components/ReferencePreview.tsx
@@ -1,0 +1,44 @@
+import React, {useEffect, useState} from 'react'
+import {useClient} from 'sanity'
+import AssetPreview from './AssetPreview'
+
+interface ReferencePreviewProps {
+  value: {_ref: string}
+}
+
+export function ReferencePreview(props: ReferencePreviewProps) {
+  const {value} = props
+  const client = useClient({apiVersion: '2023-01-01'})
+  const [asset, setAsset] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!value?._ref) {
+      setAsset(null)
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    client
+      .getDocument(value._ref)
+      .then((document) => {
+        setAsset(document?.asset || null)
+        setLoading(false)
+      })
+      .catch((err) => {
+        console.error('Error fetching referenced asset:', err)
+        setLoading(false)
+      })
+  }, [value, client])
+
+  if (loading) {
+    return <div>Loading asset...</div>
+  }
+
+  if (!asset) {
+    return null
+  }
+
+  return <AssetPreview value={asset} layout="block" />
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import {CloudinaryAssetSource} from './components/asset-source/CloudinaryAssetSo
 import {cloudinaryAssetContext} from './schema/cloudinaryAssetContext'
 import {cloudinaryAssetContextCustom} from './schema/cloudinaryAssetContextCustom'
 import {AssetListFunctions} from './components/AssetListFunctions'
+import {cloudinaryAssetDocument} from './schema/cloudinaryAssetDocument'
+import {cloudinaryAssetReference} from './schema/cloudinaryAssetReference'
 
 export {type CloudinaryAssetContext} from './schema/cloudinaryAssetContext'
 export {type CloudinaryAssetDerived} from './schema/cloudinaryAssetDerived'
@@ -23,7 +25,23 @@ export {
   cloudinaryAssetDerivedSchema,
   cloudinaryAssetContext,
   cloudinaryAssetContextCustom,
+  cloudinaryAssetDocument,
+  cloudinaryAssetReference,
 }
+
+export const cloudinaryReferencePlugin = definePlugin({
+  name: 'cloudinary-reference',
+  schema: {
+    types: [
+      cloudinaryAssetDocument,
+      cloudinaryAssetReference,
+      cloudinaryAssetSchema,
+      cloudinaryAssetDerivedSchema,
+      cloudinaryAssetContext,
+      cloudinaryAssetContextCustom,
+    ],
+  },
+})
 
 export const cloudinarySchemaPlugin = definePlugin({
   name: 'cloudinary-schema',
@@ -62,7 +80,7 @@ export const cloudinaryImageSource: AssetSource = {
 }
 
 export const cloudinaryAssetSourcePlugin = definePlugin({
-  name: 'cloudinart-asset-source',
+  name: 'cloudinary-asset-source',
   form: {
     image: {
       assetSources: [cloudinaryImageSource],

--- a/src/schema/cloudinaryAssetDocument.ts
+++ b/src/schema/cloudinaryAssetDocument.ts
@@ -1,0 +1,40 @@
+import {defineType} from 'sanity'
+import {cloudinaryAssetSchema} from './cloudinaryAsset'
+
+export const cloudinaryAssetDocument = defineType({
+  name: 'cloudinaryAssetDocument',
+  title: 'Cloudinary Asset',
+  type: 'document',
+  fields: [
+    {
+      name: 'asset',
+      type: cloudinaryAssetSchema.name,
+      title: 'Cloudinary Asset',
+    },
+  ],
+  preview: {
+    select: {
+      caption: 'asset.metadata.caption',
+      alt: 'asset.metadata.alt_text',
+      displayName: 'asset.display_name',
+      resourceType: 'asset.resource_type',
+      format: 'asset.format',
+      media: 'asset',
+    },
+    prepare({caption, alt, displayName, resourceType, format, media}) {
+      // Use caption or alt text as the title, fall back to display name
+      const title = caption || alt || displayName || 'Untitled Asset'
+
+      // Create a descriptive subtitle
+      const type = resourceType || 'image'
+      const formatInfo = format ? `(${format})` : ''
+      const subtitle = `${type} ${formatInfo}`
+
+      return {
+        title,
+        subtitle,
+        media,
+      }
+    },
+  },
+})

--- a/src/schema/cloudinaryAssetReference.ts
+++ b/src/schema/cloudinaryAssetReference.ts
@@ -1,0 +1,19 @@
+import {defineType} from 'sanity'
+import {CloudinaryReferenceInput} from '../components/CloudinaryReferenceInput'
+
+export const cloudinaryAssetReference = defineType({
+  name: 'cloudinaryAssetReference',
+  title: 'Cloudinary Asset Reference',
+  type: 'object',
+  fields: [
+    {
+      name: 'asset',
+      type: 'reference',
+      to: [{type: 'cloudinaryAssetDocument'}],
+      weak: true,
+    },
+  ],
+  components: {
+    input: CloudinaryReferenceInput,
+  },
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type CloudinaryDerivative = {
 
 export type CloudinaryAssetResponse = {
   public_id: string
+  id: string
   resource_type: string
   type: string
   url: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,10 @@ export type InsertHandlerParams = {
   assets: CloudinaryAssetResponse[]
 }
 
+export type ShowHandlerParams = {
+  isOpen: boolean
+}
+
 export interface CloudinaryMediaLibrary {
   show: (config?: {asset: any; folder: any}) => void
   hide: () => void
@@ -43,6 +47,8 @@ export type CloudinaryAsset = {
   version: number
   url: string
   secure_url: string
+  width: number
+  height: number
   derived?: CloudinaryAssetDerived[]
   display_name?: string
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,8 @@ export const openMediaSelector = (
   multiple: boolean,
   insertHandler: (params: InsertHandlerParams) => void,
   selectedAsset?: CloudinaryAsset,
-  showHandler?: () => void
+  showHandler?: () => void,
+  folder?: {resource_type?: 'image' | 'video'; path?: string}
 ) => {
   loadJS(widgetSrc, () => {
     const options: Record<string, any> = {
@@ -44,6 +45,13 @@ export const openMediaSelector = (
         public_id: selectedAsset.public_id,
         type: selectedAsset.type,
         resource_type: selectedAsset.resource_type,
+      }
+    }
+
+    if (folder) {
+      options.folder = {
+        path: folder.path,
+        resource_type: folder.resource_type,
       }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import {
   CloudinaryAssetResponse,
   CloudinaryMediaLibrary,
   InsertHandlerParams,
+  ShowHandlerParams,
 } from './types'
 
 const widgetSrc = 'https://media-library.cloudinary.com/global/all.js'
@@ -27,7 +28,8 @@ export const openMediaSelector = (
   apiKey: string,
   multiple: boolean,
   insertHandler: (params: InsertHandlerParams) => void,
-  selectedAsset?: CloudinaryAsset
+  selectedAsset?: CloudinaryAsset,
+  showHandler?: () => void
 ) => {
   loadJS(widgetSrc, () => {
     const options: Record<string, any> = {
@@ -45,7 +47,13 @@ export const openMediaSelector = (
       }
     }
 
-    window.cloudinary.openMediaLibrary(options, {insertHandler})
+    const callbacks: any = {insertHandler}
+
+    if (showHandler) {
+      callbacks.showHandler = showHandler
+    }
+
+    window.cloudinary.openMediaLibrary(options, callbacks)
   })
 }
 


### PR DESCRIPTION
# Add Cloudinary Reference Asset Plugin

## Overview
This PR introduces a new plugin mode that allows storing Cloudinary assets as document references. This approach enables reusing the same assets across multiple documents and managing them centrally.

## New Features
- Added `cloudinaryReferencePlugin` for registering all required schema types
- Added `cloudinaryAssetDocument` type to store Cloudinary assets as documents
- Added `cloudinaryAssetReference` type to reference these asset documents
- Created custom input component for selecting and managing referenced assets
- Updated README with documentation for the new reference approach

## Changes
- Enhanced `openMediaSelector` utility to support showing/hiding callbacks, so the button is disabled and shows a loading state vs being able to click it multiple times.
- Added width/height to CloudinaryAsset type
- Fixed typo in cloudinaryAssetSourcePlugin name

## Benefits
- Assets can be reused across multiple documents
- Asset updates propagate to all references (We have a webhook that handles CRUD events from Cloudinary back to Sanity)
- Centralizes asset management
- Reduces data duplication in the dataset

## Testing
Tested functionality with various asset types (images, videos) and verified that references are correctly created, updated, and displayed in the Sanity Studio interface.

## Screenshots

No asset selected
<img width="766" alt="Screenshot 2025-05-01 at 12 56 19 PM" src="https://github.com/user-attachments/assets/e4db63b3-c326-42a0-b8ac-bdd7254810fc" />

Asset (as image) selected
<img width="806" alt="Screenshot 2025-05-01 at 12 57 38 PM" src="https://github.com/user-attachments/assets/085ea3a1-f978-4272-979a-54c66decce50" />

View of component's data structure in article model
<img width="582" alt="Screenshot 2025-05-01 at 1 22 57 PM" src="https://github.com/user-attachments/assets/bbb732e6-ff05-470f-93ae-fe5434c484b3" />

View of documents stored in sanity
<img width="2101" alt="Screenshot 2025-05-01 at 1 00 39 PM" src="https://github.com/user-attachments/assets/3dbdbe41-268a-466b-9224-01abc6f3a7d5" />

Data model of stored document

<img width="1013" alt="Screenshot 2025-05-01 at 1 01 36 PM" src="https://github.com/user-attachments/assets/139e854e-c923-4f29-b2ef-140fdf70147a" />

