### PR TITLE
Handle Null Values and Anon Objects for Copy/Paste

### DIFF
--- a/src/components/CloudinaryInput.tsx
+++ b/src/components/CloudinaryInput.tsx
@@ -14,6 +14,7 @@ const CloudinaryInput = (props: ObjectInputProps) => {
   const {onChange, schemaType: type} = props
   const value = (props.value as CloudinaryAsset) || undefined
 
+  /* eslint-disable camelcase */
   const handleSelect = useCallback(
     (payload: InsertHandlerParams) => {
       const [asset] = payload.assets
@@ -66,6 +67,19 @@ const CloudinaryInput = (props: ObjectInputProps) => {
         }
       }
 
+      // Handle derived field - only include if not null
+      if (asset.derived) {
+        const derivedWithType = asset.derived.map((derivedItem) => ({
+          ...derivedItem,
+          _type: 'derived',
+        }))
+
+        updatedAsset = {
+          ...updatedAsset,
+          derived: derivedWithType,
+        }
+      }
+
       onChange(
         PatchEvent.from([
           set(
@@ -101,6 +115,7 @@ const CloudinaryInput = (props: ObjectInputProps) => {
       <WidgetInput onSetup={() => setShowSettings(true)} openMediaSelector={action} {...props} />
     </>
   )
+  /* eslint-enable camelcase */
 }
 
 export default CloudinaryInput

--- a/src/components/CloudinaryInput.tsx
+++ b/src/components/CloudinaryInput.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useState} from 'react'
 import WidgetInput from './WidgetInput'
 import {nanoid} from 'nanoid'
 import {ObjectInputProps, PatchEvent, set} from 'sanity'
-import {CloudinaryAsset} from '../types'
+import {CloudinaryAsset, CloudinaryAssetResponse} from '../types'
 import {useSecrets} from '@sanity/studio-secrets'
 import {InsertHandlerParams} from '../types'
 import {openMediaSelector} from '../utils'
@@ -24,6 +24,29 @@ const CloudinaryInput = (props: ObjectInputProps) => {
 
       let updatedAsset = asset
 
+      // Update the asset with the new custom values
+      const assetWithoutNulls = Object.fromEntries(
+        Object.entries(asset).filter(([_, assetValue]) => assetValue !== null)
+      ) as CloudinaryAssetResponse
+
+      // Ensure we preserve the required fields from the original asset
+      const requiredFields = {
+        public_id: asset.public_id,
+        resource_type: asset.resource_type,
+        type: asset.type,
+        url: asset.url,
+        secure_url: asset.secure_url,
+        format: asset.format,
+        width: asset.width,
+        height: asset.height,
+        bytes: asset.bytes,
+        tags: asset.tags,
+      }
+      updatedAsset = {
+        ...assetWithoutNulls,
+        ...requiredFields,
+      }
+
       //The metadata in Sanity Studio cannot contain special characters,
       //hence the cloudinary metadata (context) needs to be transformed to valid object keys
       if (asset.context) {
@@ -35,7 +58,7 @@ const CloudinaryInput = (props: ObjectInputProps) => {
 
         // Update the asset with the new custom values
         updatedAsset = {
-          ...asset,
+          ...updatedAsset,
           context: {
             ...asset.context,
             custom: objectWithRenamedKeys,

--- a/src/schema/cloudinaryAsset.ts
+++ b/src/schema/cloudinaryAsset.ts
@@ -68,7 +68,7 @@ export const cloudinaryAssetSchema = defineType({
     {
       type: 'array',
       name: 'derived',
-      of: [{type: 'cloudinary.assetDerived'}],
+      of: [{type: 'cloudinary.assetDerived', name: 'derived'}],
     },
     {
       type: 'string',


### PR DESCRIPTION
### Description

**What changes are introduced?**
When selecting an image from Cloudinary, null values are removed from the object. It has been found that if the Cloudinary object contains a null value, the copy/paste functionality does not work. This can be replicated on:
 - Example assets in the Cloudinary account, where duration and user upload data are `null`
 - Uploaded images to Cloudinary, where duration is `null`

This also fixes an [issue](https://github.com/sanity-io/sanity-plugin-cloudinary/issues/85) where, if transformations are used, the derived objects do not have a _type, which prevents copy/paste actions.

Object with Null `Duration` Value from plugin v1.3.1 - Paste Action Fails
<img width="1672" height="1092" alt="image" src="https://github.com/user-attachments/assets/48eaf4e0-88eb-4982-9905-213bb4f8cf88" />

Object without null values, selected by updated plugin - Paste Action Succeeds
<img width="1702" height="1238" alt="image" src="https://github.com/user-attachments/assets/c1eccfdd-174d-40a8-bfda-62647be1c70d" />

**Why are these changes introduced?**
 - Null values and anonymous objects are preventing the pasting of the copied object within Sanity Studio

**What issue(s) does this solve? (with link, if possible)**
 - Related to [this](https://github.com/sanity-io/sanity-plugin-cloudinary/issues/85), also includes null bux found during investigation.

### What to review

**What steps should the reviewer take in order to review?**
Review code updates to ensure plugin functionality continues to work. From the type, it appears that some fields are required, so the code has been updated to ensure these are retained.
**What parts/flows of the application/packages/tooling is affected?**
 - Importing of data into Sanity fields.


### Testing

**Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test**

Testing was done using instructions in https://github.com/sanity-io/plugin-kit#testing-a-plugin-in-sanity-studio using yalc. 

Used my own Cloudinary account with pre-uploaded example assets as well as my own image assets, both with and without transformations.

