### PR TITLE
fix(deps): add sanity v5 in allowed peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sanity/icons": "^3.7.0",
         "@sanity/incompatible-plugin": "^1.0.5",
-        "@sanity/studio-secrets": "^3.0.1",
+        "@sanity/studio-secrets": "^3.0.3",
         "@sanity/ui": "^2.15.2",
         "nanoid": "^4.0.0"
       },
@@ -51,7 +51,7 @@
       "peerDependencies": {
         "react": "^18.3 || ^19",
         "react-dom": "^18.3 || ^19",
-        "sanity": "^3 || ^4.0.0-0",
+        "sanity": "^3 || ^4.0.0-0 || ^5.0.0",
         "styled-components": "^6.0"
       }
     },
@@ -6155,9 +6155,9 @@
       }
     },
     "node_modules/@sanity/studio-secrets": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/studio-secrets/-/studio-secrets-3.0.1.tgz",
-      "integrity": "sha512-r9X/2t0xA5HHZyWZQvj8QQTE/mOm0Y5PsoZLKffMERvr8cDpRXYmzr33rRv5teMcWWUwYBMurcoGe29twvFDMA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@sanity/studio-secrets/-/studio-secrets-3.0.3.tgz",
+      "integrity": "sha512-L9eNKVOelFhnFxM3WTyXfal63iiOjlHdXiwdJg9Iz9+5mjXOiHgtiVSWSlkqsexTDgTqAyONcQGL6FMJxSOF6w==",
       "license": "MIT",
       "dependencies": {
         "@sanity/incompatible-plugin": "^1.0.5",
@@ -6168,7 +6168,7 @@
       },
       "peerDependencies": {
         "react": "^18.2.0 || ^19",
-        "sanity": "^3.36.4",
+        "sanity": "^3.36.4 || ^4.0.0-0 || ^5.0.0",
         "styled-components": "^6.1"
       }
     },
@@ -30476,9 +30476,9 @@
       }
     },
     "@sanity/studio-secrets": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/studio-secrets/-/studio-secrets-3.0.1.tgz",
-      "integrity": "sha512-r9X/2t0xA5HHZyWZQvj8QQTE/mOm0Y5PsoZLKffMERvr8cDpRXYmzr33rRv5teMcWWUwYBMurcoGe29twvFDMA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@sanity/studio-secrets/-/studio-secrets-3.0.3.tgz",
+      "integrity": "sha512-L9eNKVOelFhnFxM3WTyXfal63iiOjlHdXiwdJg9Iz9+5mjXOiHgtiVSWSlkqsexTDgTqAyONcQGL6FMJxSOF6w==",
       "requires": {
         "@sanity/incompatible-plugin": "^1.0.5",
         "@sanity/ui": "^2.10.10"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@sanity/icons": "^3.7.0",
     "@sanity/incompatible-plugin": "^1.0.5",
-    "@sanity/studio-secrets": "^3.0.1",
+    "@sanity/studio-secrets": "^3.0.3",
     "@sanity/ui": "^2.15.2",
     "nanoid": "^4.0.0"
   },
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "react": "^18.3 || ^19",
     "react-dom": "^18.3 || ^19",
-    "sanity": "^3 || ^4.0.0-0",
+    "sanity": "^3 || ^4.0.0-0 || ^5.0.0",
     "styled-components": "^6.0"
   },
   "engines": {


### PR DESCRIPTION
### Description
This PR updates the package to support Sanity 5.x by modifying peer dependencies and upgrading the @sanity/studio-secrets dependency to a version that also supports Sanity 5.x.

Updates peer dependency to accept sanity versions 3, 4, and 5
Upgrades @sanity/studio-secrets from 3.0.1 to 3.0.3 which includes sanity 5.x support
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
